### PR TITLE
Updated to use java17, Intellij version and use default SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Kick Assembler (... and chew bubble gum) | ChangeLog
 
+## [1.10.0]
+
+### Changed
+- updated for IntelliJ 2023.3.5
+- use default project SDK if none is set in the Kick Assembler plugin settings
+
 ## [1.9.0]
 
 ### Changed

--- a/app/src/main/java/de/achimonline/kickassembler/acbg/project/KickAssemblerProjectJdkTable.java
+++ b/app/src/main/java/de/achimonline/kickassembler/acbg/project/KickAssemblerProjectJdkTable.java
@@ -6,7 +6,7 @@ import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.projectRoots.SdkTypeId;
 import com.intellij.openapi.util.SystemInfo;
 import de.achimonline.kickassembler.acbg.exception.JdkException;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
 
@@ -14,19 +14,32 @@ public class KickAssemblerProjectJdkTable {
 
     private static final ProjectJdkTable PROJECT_JDK_TABLE = ProjectJdkTable.getInstance();
 
-    public static String getJavaExecutableFromJdkNameOrPath(String jdkNameOrPath) throws JdkException {
-        if (StringUtils.isNotEmpty(jdkNameOrPath)) {
-            for (Sdk jdk : PROJECT_JDK_TABLE.getAllJdks()) {
-                if (jdk.getSdkType() instanceof JavaSdk) {
-                    String homePath = jdk.getName().equals(jdkNameOrPath) ? jdk.getHomePath() : jdkNameOrPath;
-                    String binPath = homePath + File.separator + "bin";
-                    File javaExecutable = new File(binPath + File.separator + (SystemInfo.isWindows ? "java.exe" : "java"));
+    public static String getJavaExecutableFromJdkNameOrPath(final String jdkNameOrPath) throws JdkException {
+        final String nameOrPath;
 
-                    if (javaExecutable.exists() &&
+        if (StringUtils.isEmpty(jdkNameOrPath)) {
+            nameOrPath =
+                    PROJECT_JDK_TABLE
+                            .getSdksOfType(PROJECT_JDK_TABLE.getDefaultSdkType())
+                            .stream()
+                            .findFirst()
+                            .orElseThrow(() -> new JdkException("Didn't find default SDK"))
+                            .getHomePath();
+        }
+        else {
+            nameOrPath = jdkNameOrPath;
+        }
+
+        for (Sdk jdk : PROJECT_JDK_TABLE.getAllJdks()) {
+            if (jdk.getSdkType() instanceof JavaSdk) {
+                String homePath = jdk.getName().equals(nameOrPath) ? jdk.getHomePath() : nameOrPath;
+                String binPath = homePath + File.separator + "bin";
+                File javaExecutable = new File(binPath + File.separator + (SystemInfo.isWindows ? "java.exe" : "java"));
+
+                if (javaExecutable.exists() &&
                         javaExecutable.isFile() &&
                         javaExecutable.canExecute()) {
-                        return javaExecutable.getPath();
-                    }
+                    return javaExecutable.getPath();
                 }
             }
         }

--- a/app/src/main/java/de/achimonline/kickassembler/acbg/runconfiguration/KickAssemblerCommandLine.java
+++ b/app/src/main/java/de/achimonline/kickassembler/acbg/runconfiguration/KickAssemblerCommandLine.java
@@ -13,7 +13,7 @@ import de.achimonline.kickassembler.acbg.sdk.KickAssemblerSdk;
 import de.achimonline.kickassembler.acbg.settings.KickAssemblerSettings;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 

--- a/app/src/main/java/de/achimonline/kickassembler/acbg/sdk/KickAssemblerSdk.java
+++ b/app/src/main/java/de/achimonline/kickassembler/acbg/sdk/KickAssemblerSdk.java
@@ -2,19 +2,14 @@ package de.achimonline.kickassembler.acbg.sdk;
 
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.projectRoots.AdditionalDataConfigurable;
-import com.intellij.openapi.projectRoots.Sdk;
-import com.intellij.openapi.projectRoots.SdkAdditionalData;
-import com.intellij.openapi.projectRoots.SdkModel;
-import com.intellij.openapi.projectRoots.SdkModificator;
-import com.intellij.openapi.projectRoots.SdkType;
+import com.intellij.openapi.projectRoots.*;
 import com.intellij.openapi.util.IconLoader;
 import de.achimonline.kickassembler.acbg.exception.JdkException;
 import de.achimonline.kickassembler.acbg.exception.SdkException;
 import de.achimonline.kickassembler.acbg.project.KickAssemblerProjectJdkTable;
 import de.achimonline.kickassembler.acbg.settings.KickAssemblerSettings;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -26,6 +21,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -76,8 +72,9 @@ public class KickAssemblerSdk extends KickAssemblerSdkType {
     }
 
     @Override
-    public @NotNull String suggestSdkName(String currentSdkName, @NotNull String sdkHome) {
-        return getVersionString(sdkHome);
+    public @NotNull String suggestSdkName(final String currentSdkName,
+                                          final @NotNull String sdkHome) {
+        return Objects.requireNonNull(getVersionString(sdkHome));
     }
 
     @Nullable
@@ -107,13 +104,13 @@ public class KickAssemblerSdk extends KickAssemblerSdkType {
 
     @Nullable
     @Override
-    public String getVersionString(@NotNull Sdk sdk) {
-        return getVersionString(sdk.getHomePath());
+    public String getVersionString(@NotNull final Sdk sdk) {
+        return sdk.getHomePath() != null ? getVersionString(sdk.getHomePath()) : null;
     }
 
     @Nullable
     @Override
-    public String getVersionString(String sdkHome) {
+    public String getVersionString(@NotNull final String sdkHome) {
         if (StringUtils.isNotEmpty(sdkHome)) {
             if (cachedVersions.containsKey(sdkHome)) {
                 return cachedVersions.get(sdkHome);
@@ -137,8 +134,11 @@ public class KickAssemblerSdk extends KickAssemblerSdkType {
         return null;
     }
 
-    private String determineSdkVersionFromSdkHome(String sdkHome) throws JdkException, SdkException, IOException, InterruptedException {
-        String javaExecutable = KickAssemblerProjectJdkTable.getJavaExecutableFromJdkNameOrPath(KickAssemblerSettings.storedSettings(ApplicationManager.getApplication()).getJrePathOrName());
+    private String determineSdkVersionFromSdkHome(final String sdkHome) throws JdkException, SdkException, IOException, InterruptedException {
+        final String javaExecutable =
+                KickAssemblerProjectJdkTable
+                        .getJavaExecutableFromJdkNameOrPath(KickAssemblerSettings.storedSettings(ApplicationManager.getApplication())
+                                .getJrePathOrName());
 
         String[] cmdArray = new String[]{
                 javaExecutable, "-jar", determineJarPathFromSdkHome(sdkHome)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 pluginName = kick-assembler-acbg
-pluginVersion = 1.9.0
-pluginSinceBuild = 203
+pluginVersion = 1.10.0
+pluginSinceBuild = 233
 
 platformType = IC
-platformVersion = 2022.2.4
+platformVersion = 2023.3.5
 platformPlugins = java
 
-javaVersion = 11
+javaVersion = 17


### PR DESCRIPTION
Updated to use java17, Intellij version and use default SDK if none is set in the Kick Assembler plugin settings.